### PR TITLE
Check if the IBM CP4NA operator has finished installation

### DIFF
--- a/ansible/roles/cp4na_operator_instance/tasks/main.yaml
+++ b/ansible/roles/cp4na_operator_instance/tasks/main.yaml
@@ -1,4 +1,16 @@
 ---
+- name: check IBM CP4NA operator csv status to ensure the operator has finished installed
+  kubernetes.core.k8s_info:
+    kind: ClusterServiceVersion
+    api_version: operators.coreos.com/v1alpha1
+    namespace: "{{ cp4na_ns }}"
+    label_selectors:
+      - "operators.coreos.com/ibm-tnc-orchestration-operator.{{ cp4na_ns }}"
+  register: cp4na_csv
+  until: cp4na_csv.resources[0].status.phase == "Succeeded"
+  retries: 40
+  delay: 15
+
 - name: Check if the "{{ file_dest_dir }}" directory exists and create it if it doesn't exist
   ansible.builtin.file:
     path: "{{ file_dest_dir }}"


### PR DESCRIPTION
A check to see if IBM CP4NA operator got installed successfully has been inserted before the creation of its corresponding orchestration instance when using Ansible playbooks and roles.

Note:- 
1. The number of retries may have to be adjusted in the future based on further usage of the IBM CP4NA operator instance playbook.
2. An option to utilize the ansible k8s module's wait option for the CSV resource can be explored as a future scope.