### PR TITLE
Install Ansible lifecycle driver for CP4NA

### DIFF
--- a/ansible/cp4na_ansible_driver_install.yaml
+++ b/ansible/cp4na_ansible_driver_install.yaml
@@ -1,0 +1,13 @@
+---
+- name: Ansible lifecycle driver for IBM CP4NA install playbook
+  hosts: localhost
+  roles:
+    - role: cp4na_ansible_driver_install
+      vars:
+        ansible_work_dir: /tmp/ansible
+        cp4na_ns: ibmcp4na
+        file_dest_dir: /tmp/siteplanner_yaml_files
+        kafka_component: iaf-system-kafka-bootstrap
+        kafka_port: 9092       
+        role_name: cp4na_operator_instance
+        ver: 3.5.1

--- a/ansible/roles/cp4na_ansible_driver_install/defaults/main.yaml
+++ b/ansible/roles/cp4na_ansible_driver_install/defaults/main.yaml
@@ -1,0 +1,2 @@
+kafka_component: cp4na-o-events-kafka-bootstrap
+kafka_port: 9092

--- a/ansible/roles/cp4na_ansible_driver_install/tasks/main.yaml
+++ b/ansible/roles/cp4na_ansible_driver_install/tasks/main.yaml
@@ -1,0 +1,50 @@
+---
+- name: Check if the "{{ file_dest_dir }}" directory exists and create it if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ file_dest_dir }}"
+    state: directory
+    mode: '0755'
+
+
+- name: Check if the "{{ ansible_work_dir }}/roles/{{ role_name }}/templates" directory exists and create it if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ ansible_work_dir }}/roles/{{ role_name }}/templates"
+    state: directory
+    mode: '0755'
+
+
+
+- name: Download Ansible lifecycle driver tgz file
+  ansible.builtin.get_url:
+   url: "https://github.com/IBM/ansible-lifecycle-driver/releases/download/{{ ver }}/ansiblelifecycledriver-{{ ver }}.tgz"
+   dest: "{{ file_dest_dir }}/ansiblelifecycledriver-{{ ver }}.tgz"
+   mode: '0664'
+
+
+- name: Deploy the Ansible lifecycle driver using Helm
+  kubernetes.core.helm:
+    release_name: ansiblelifecycledriver
+    chart_ref: "{{ file_dest_dir }}/ansiblelifecycledriver-{{ ver }}.tgz"
+    release_namespace: "{{ cp4na_ns }}"
+    state: present
+    values: 
+      app.config.override.messaging.connection_address: "{{ kafka_component }}:{{ kafka_port }}"
+
+
+- name: Create a script to get the tls secret from the Ansible Lifecycle driver
+  copy:
+    dest: "{{ file_dest_dir }}/ald-tls.sh"
+    content: |
+      oc get secret ald-tls -o 'go-template={{ '{{' }}index .data "tls.crt"{{ '}}' }}' -n {{ cp4na_ns }} | base64 -d > {{ file_dest_dir }}/ald-tls.pem
+
+- name: Set Permissions for the script
+  file:
+    path: "{{ file_dest_dir }}/ald-tls.sh"
+    mode: 0777
+
+
+- name: Get the tls secret from the Ansible Lifecycle driver
+  ansible.builtin.shell: "{{ file_dest_dir }}/ald-tls.sh"
+  args:
+    executable: /bin/bash
+


### PR DESCRIPTION
Created an ansible playbook and role to download the Ansible lifecycle driver for the IBM CP4NA operator's siteplanner component - https://github.com/IBM/ansible-lifecycle-driver

1. This Ansible role would download the .tgz file for the driver and then install it using Helm from the kubernetes (kubernetes.core.k8s) Ansible module.
2. Extracts the TLS secret from the driver to be used to onboard the driver into the CP4NA operator.