### PR TITLE
Pre-req packages and binary install updates

### DIFF
--- a/ansible/pre_req.yaml
+++ b/ansible/pre_req.yaml
@@ -2,11 +2,30 @@
 - name: Download and apply kubernetes yaml manifests locally
   hosts: localhost
 
+  vars:
+    # value of 'stable' can be provided as well
+    oc_ver: 4.10.0-rc.8
+    argocdcli_ver_tag: v2.5.0
+
+  roles:
+    - role: helm_install
+
   tasks:
   - name: Install kubernetes Python module
-    pip:
-      name: kubernetes
+    ansible.builtin.pip:
+      name:
+        - kubernetes
+        - openshift
+        - PyYAML
 
-  - name: Install OpenShift Python module
-    pip:
-      name: openshift
+  - name: unarchive oc
+    ansible.builtin.unarchive:
+      src: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/{{ oc_ver }}/openshift-client-linux.tar.gz"
+      dest: /usr/local/bin/
+      remote_src: true
+
+  - name: Download and install ArgoCD CLI from binary file
+    ansible.builtin.get_url:
+      url: "https://github.com/argoproj/argo-cd/releases/download/{{ argocdcli_ver_tag }}/argocd-linux-amd64"
+      dest: /usr/local/bin/argocd
+      mode: 0555


### PR DESCRIPTION
Refactored the Ansible playbook for pre-requisites (https://github.com/redhat-eets/cp4na/blob/main/ansible/pre_req.yaml) that installs pip packages and included the following changes:-
1. Install PyYAML pip package
2. Install Helm by referring the Ansible role for installing Helm
3. Install the binaries of oc client and ArgoCD CLI.

Closes #62, #55 