### PR TITLE
Ansible task to push CP4NA assemblies and folder checks

### DIFF
--- a/ansible/cp4na_lmctl_deploy.yaml
+++ b/ansible/cp4na_lmctl_deploy.yaml
@@ -7,4 +7,5 @@
         cp4na_admin_api_key: <insert CP4NA GUI admin user's api key token>
         cp4na_ansible_driver_port:
         cp4na_ns: ibmcp4na
+        cp4na_repo_dest: /tmp/siteplanner_yaml_files
         file_dest_dir: /tmp/siteplanner_yaml_files 

--- a/ansible/roles/cp4na_lmctl_deploy/tasks/main.yaml
+++ b/ansible/roles/cp4na_lmctl_deploy/tasks/main.yaml
@@ -1,4 +1,10 @@
 ---
+- name: Check if the "{{ file_dest_dir }}" directory exists and create it if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ file_dest_dir }}"
+    state: directory
+    mode: '0755'
+
 - name: Install LMCTL Python module for IBM CP4NA
   ansible.builtin.pip:
     name: lmctl
@@ -25,3 +31,19 @@
     - lmctl resourcedriver add --type ansible --url https://ansible-lifecycle-driver:'{{ cp4na_ansible_driver_port }}' dev --certificate '{{ file_dest_dir }}'/ald-tls.pem
   environment:
     LMCONFIG: "{{ file_dest_dir }}/lmctl.yaml"  
+
+- name: Check if the "{{ cp4na_repo_dest }}" directory exists and create it if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ cp4na_repo_dest }}"
+    state: directory
+    mode: '0755'
+
+- name: Upload/push the CP4NA automation assembly descriptors into the CP4NA SitePlanner
+  ansible.builtin.shell: "lmctl project push dev"
+  args:
+    chdir: "{{ item }}"
+  with_items:
+    - "{{ cp4na_repo_dest }}/nodeconfig-master"
+    - "{{ cp4na_repo_dest }}/ocp-cluster-automation-develop"
+    - "{{ cp4na_repo_dest }}/prereqs-datamodel-master"
+    - "{{ cp4na_repo_dest }}/server-automation-master"


### PR DESCRIPTION
Added ansible tasks to upload/push the CP4NA assembly descriptors using LMCTL after downloading them through git clone earlier and to do a couple of folder checks for the folders involved in LMCTL's ansible tasks.

Fixes #58 