### PR TITLE
Added ansible task for RHACM assisted deployment pull secret

### DIFF
--- a/acm_postdeploy/assisted-deployment-pull-secret-acm.yaml
+++ b/acm_postdeploy/assisted-deployment-pull-secret-acm.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    agentclusterinstalls.extensions.hive.openshift.io: "true"
+  name: assisted-deployment-pull-secret
+  namespace: open-cluster-management
+stringData:
+  .dockerconfigjson: "{{ pull_secret.stdout | from_yaml }}"
+  type: kubernetes.io/dockerconfigjson

--- a/ansible/roles/acm_postdeploy/tasks/main.yaml
+++ b/ansible/roles/acm_postdeploy/tasks/main.yaml
@@ -27,6 +27,13 @@
     mode: '0755'
 
 
+- name: Check if the "{{ file_dest_dir }}" directory exists and create it if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ file_dest_dir }}"
+    state: directory
+    mode: '0755'
+
+
 - name: Download AgentServiceConfig CR creation yaml manifest template file
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/redhat-eets/cp4na/main/acm_postdeploy/agent_service_config.yaml
@@ -40,8 +47,30 @@
     dest: "{{ file_dest_dir }}/agent_service_config.yaml"
 
 
-
 - name: Apply AgentServiceConfig CR creation creation yaml manifest file
   kubernetes.core.k8s:
     state: present
     src: "{{ file_dest_dir }}/agent_service_config.yaml"
+
+
+- name: Download yaml manifest file template for assisted deployment pull secret object from github repo for CP4NA
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/redhat-eets/cp4na/main/acm_postdeploy/assisted-deployment-pull-secret-acm.yaml
+    dest: "{{ ansible_work_dir }}/roles/{{ role_name }}/templates/assisted-deployment-pull-secret-acm.j2"
+    mode: '0664'
+
+- name: Extract user pull secret from hub cluster for the assisted deployment pull secret object
+  shell: oc extract -n openshift-config secret/pull-secret  --to=-
+  register: pull_secret
+
+
+- name: Creation of assisted deployment pull secret yaml manifest file from template
+  template:
+    src: "{{ ansible_work_dir }}/roles/{{ role_name }}/templates/assisted-deployment-pull-secret-acm.j2"
+    dest: "{{ file_dest_dir }}/assisted-deployment-pull-secret-acm.yaml"
+
+
+- name: Apply creation of assisted deployment pull secret
+  kubernetes.core.k8s:
+    state: present
+    src: "{{ file_dest_dir }}/assisted-deployment-pull-secret-acm.yaml"


### PR DESCRIPTION
Added an ansible task that creates a secret (containing assisted deployment pull secret) for RHACM in the open-cluster-management namespace that is needed for CP4NA to deploy SNOs. The secret manifest file has also been included to be put into the folder - https://github.com/redhat-eets/cp4na/tree/main/acm_postdeploy

Also added a folder check for ACM's post deploy files that are created by the file - https://github.com/redhat-eets/cp4na/blob/main/ansible/roles/acm_postdeploy/tasks/main.yaml