### PR TITLE
add Ansible task to connect github repo to ArgoCD

### DIFF
--- a/ansible/pre_req.yaml
+++ b/ansible/pre_req.yaml
@@ -7,6 +7,8 @@
     oc_ver: 4.10.0-rc.8
     argocdcli_ver_tag: v2.5.0
     cp4na_repo_dest: /tmp/siteplanner_yaml_files
+    ztp_github_repo: <insert github repo link here>
+    github_token: <insert github personal access token here>
 
   roles:
     - role: helm_install
@@ -44,3 +46,21 @@
       dest: "{{ cp4na_repo_dest }}"
       key_file: ~/.ssh/id_rsa
       force: yes
+
+  - name: Download yaml manifest file template for github account secret from github repo
+    ansible.builtin.get_url:
+      url: https://raw.githubusercontent.com/redhat-eets/cp4na/main/ztp_deploy/github-secret.yaml
+      dest: "{{ cp4na_repo_dest }}/templates/github-secret.j2"
+      mode: '0664'
+
+
+  - name: Create github account secret yaml manifest file from template
+    template:
+      src: "{{ cp4na_repo_dest }}/templates/github-secret.j2"
+      dest: "{{ cp4na_repo_dest }}/github-secret.yaml"
+
+
+  - name: Apply creation of github account secret and connect to repo in ArgoCD
+    kubernetes.core.k8s:
+      state: present
+      src: "{{ cp4na_repo_dest }}/github-secret.yaml"

--- a/ztp_deploy/github-secret.yaml
+++ b/ztp_deploy/github-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: private-repo
+  name: private-repo-ztp
   namespace: openshift-gitops
   labels:
     argocd.argoproj.io/secret-type: repository


### PR DESCRIPTION
Added an Ansible task to create a Github repo secret that is used to connect the repo to ArgoCD as part of the pre-requisites before proceeding with SNO ZTP deployment using CP4NA.