### PR TITLE
Overwrite default variables in playbooks by user

### DIFF
--- a/ansible/acm_postinstall.yaml
+++ b/ansible/acm_postinstall.yaml
@@ -5,7 +5,9 @@
     - role: acm_postdeploy
       vars:
        ansible_work_dir: /tmp/ansible
-       db_volume_size:       
+       # Uncomment the following and include value to overwrite default value of '10Gi'  
+       #db_volume_size:       
        file_dest_dir: /tmp/acm_yaml_files
-       fs_volume_size: 
+       # Uncomment the following and include value to overwrite default value of '20Gi'
+       #fs_volume_size: 
        role_name: acm_postdeploy   

--- a/ansible/assisted_installer_setup.yaml
+++ b/ansible/assisted_installer_setup.yaml
@@ -17,7 +17,8 @@
       vars:
         ai_setup_dir: /tmp/ai_onprem_yaml_files/
         ai_file_tag: v2.5.0
-        svc_base_url: 
+        # Uncomment the following and include value to overwrite default value of '127.0.0.1'
+        #svc_base_url: 
         svc_name: assisted-installer
         system_path: /etc/systemd/system/
     - role: delete_file

--- a/ansible/cp4na_lmctl_deploy.yaml
+++ b/ansible/cp4na_lmctl_deploy.yaml
@@ -5,7 +5,8 @@
     - role: cp4na_lmctl_deploy
       vars:
         cp4na_admin_api_key: <insert CP4NA GUI admin user's api key token>
-        cp4na_ansible_driver_port:
+        # Uncomment the following and include value to overwrite default value of '8293'
+        #cp4na_ansible_driver_port:
         cp4na_ns: ibmcp4na
         cp4na_repo_dest: /tmp/siteplanner_yaml_files
         file_dest_dir: /tmp/siteplanner_yaml_files 

--- a/ansible/dhcp_server_setup.yaml
+++ b/ansible/dhcp_server_setup.yaml
@@ -17,8 +17,8 @@
       vars:
         image_name: 4km3/dnsmasq
         image_tag: 2.86-r0
-        registry_username:
-        registry_password:
+        registry_username: <insert username value>
+        registry_password: <insert password value>
         registry_name: docker.io
         registry_auth_file: /tmp/auth.json
     - role: ip_address_assign


### PR DESCRIPTION
Refactored the following Ansible playbooks to allow user to insert values for default variables which will plug in with default values if the user doesn't insert them:-
1.  https://github.com/redhat-eets/cp4na/blob/main/ansible/acm_postinstall.yaml
2. https://github.com/redhat-eets/cp4na/blob/main/ansible/assisted_installer_setup.yaml
3. https://github.com/redhat-eets/cp4na/blob/main/ansible/cp4na_lmctl_deploy.yaml

Included prompt for user to enter values in the following playbook - 
4. https://github.com/redhat-eets/cp4na/blob/main/ansible/dhcp_server_setup.yaml

Fixes #72 